### PR TITLE
Add: MQTT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ chargeflow.csv
 
 # Development
 .turbo/
+.local

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - 🌙 **Dark mode** with system-preference detection and manual toggle
 - 🌍 **Multi-language** — German & English with browser auto-detection
 - 📄 **CSV export** — automatic backup of all data to a CSV file
+- 📡 **Local MQTT push** — publishes API snapshot to Mosquitto/Home Assistant
 - 🐳 **Docker-ready** — standard image + AIO image with Cloudflare Tunnel
 - 📱 **Mobile-first** — designed for phones, works everywhere
 
@@ -109,6 +110,13 @@ No port mapping needed — traffic goes through the tunnel.
 | `NODE_ENV` | `production` | Runtime mode in Docker images (enables production hardening paths) |
 | `DB_PATH` | `/data/chargeflow.db` | Path to SQLite database file |
 | `CSV_PATH` | `/data/chargeflow.csv` | Path to CSV export file (set to `""` to disable) |
+| `MQTT_ENABLED` | `false` | Enable local MQTT push integration |
+| `MQTT_BROKER_URL` | `""` | MQTT broker URL, e.g. `mqtt://192.168.1.10:1883` |
+| `MQTT_USERNAME` | `""` | MQTT username |
+| `MQTT_PASSWORD` | `""` | MQTT password |
+| `MQTT_TOPIC_PREFIX` | `chargeflow` | Base topic for published state |
+| `MQTT_DISCOVERY_PREFIX` | `homeassistant` | Home Assistant MQTT discovery prefix |
+| `MQTT_CLIENT_ID` | `""` | Optional MQTT client ID |
 | `TUNNEL_TOKEN` | _(none)_ | Optional Cloudflare Tunnel token (AIO image only, pass via `-e TUNNEL_TOKEN=...`) |
 
 If `NODE_ENV` is not set (or set to anything other than `production`), the backend uses development behavior.
@@ -137,8 +145,52 @@ The backend exposes a REST API under `/api`. Full specification: [`docs/openapi.
 | `GET` | `/api/car` | Get vehicle data |
 | `PUT` | `/api/car` | Create/update vehicle |
 | `GET` | `/api/sessions` | List all charging sessions |
-| `POST` | `/api/sessions` | Add or replace a session |
+| `POST` | `/api/sessions` | Add a session |
+| `PUT` | `/api/sessions/:id` | Update a session |
 | `DELETE` | `/api/sessions/:id` | Delete a session |
+| `GET` | `/api/mqtt` | Get MQTT configuration (without plain password) |
+| `PUT` | `/api/mqtt` | Save/update MQTT broker configuration |
+| `POST` | `/api/mqtt/push` | Trigger manual MQTT snapshot push |
+
+### MQTT / Home Assistant Integration
+
+ChargeFlow can push the full local API snapshot (`car`, `sessions`, aggregated `statistics`) to a local MQTT broker (e.g. Mosquitto).
+
+- Home Assistant MQTT discovery publishes multiple sensor entities automatically:
+  - `Car Name`
+  - `Battery Capacity` (`kWh`)
+  - `Max DC Charging` (`kW`)
+  - `Max AC Charging` (`kW`)
+  - `Total Cost` (`EUR`)
+  - `Total Energy` (`kWh`)
+  - `Session Count`
+  - `Avg Price per kWh` (`EUR/kWh`)
+  - `Current Month Energy` (`kWh`)
+  - `Current Month Cost` (`EUR`)
+  - `Avg Energy per Month` (`kWh/month`)
+  - `Avg Cost per Month` (`EUR/month`)
+- The Home Assistant **device name is the configured car name** from the app.
+- All API information is available as JSON attributes on each discovered sensor entity.
+- On every mutation (`PUT /api/car`, `POST/PUT/DELETE /api/sessions`), ChargeFlow pushes an updated MQTT snapshot.
+
+Example MQTT config via API:
+
+```bash
+curl -X PUT http://localhost:7920/api/mqtt \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "enabled": true,
+    "brokerUrl": "mqtt://192.168.1.10:1883",
+    "username": "homeassistant",
+    "password": "supersecret",
+    "topicPrefix": "chargeflow",
+    "discoveryPrefix": "homeassistant",
+    "clientId": "chargeflow-server"
+  }'
+
+# Optional: force a manual push
+curl -X POST http://localhost:7920/api/mqtt/push
+```
 
 ### Example
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,6 +19,8 @@ tags:
     description: Vehicle configuration (single vehicle, id = 1)
   - name: Sessions
     description: Charging session management
+  - name: MQTT
+    description: Local MQTT push integration for Home Assistant
 
 paths:
   /api/car:
@@ -57,7 +59,7 @@ paths:
       summary: Create or update vehicle data
       description: |
         Upserts the vehicle configuration (always id = 1).
-        Triggers a CSV re-sync if `CSV_PATH` is configured.
+        Triggers a CSV re-sync if `CSV_PATH` is configured and pushes a MQTT snapshot if MQTT is enabled.
       operationId: upsertCar
       requestBody:
         required: true
@@ -111,7 +113,7 @@ paths:
       summary: Add a charging session
       description: |
         Inserts a new charging session.
-        The client generates the UUID. Triggers a CSV re-sync if `CSV_PATH` is configured.
+        The client generates the UUID. Triggers a CSV re-sync if `CSV_PATH` is configured and pushes a MQTT snapshot if MQTT is enabled.
       operationId: addSession
       requestBody:
         required: true
@@ -140,7 +142,7 @@ paths:
       summary: Update a charging session
       description: |
         Updates an existing charging session by UUID.
-        Triggers a CSV re-sync if `CSV_PATH` is configured.
+        Triggers a CSV re-sync if `CSV_PATH` is configured and pushes a MQTT snapshot if MQTT is enabled.
       operationId: updateSession
       parameters:
         - name: id
@@ -177,7 +179,7 @@ paths:
       summary: Delete a charging session
       description: |
         Deletes the charging session with the given UUID.
-        Triggers a CSV re-sync if `CSV_PATH` is configured.
+        Triggers a CSV re-sync if `CSV_PATH` is configured and pushes a MQTT snapshot if MQTT is enabled.
       operationId: deleteSession
       parameters:
         - name: id
@@ -194,6 +196,75 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/OkResponse"
+
+  /api/mqtt:
+    get:
+      tags: [MQTT]
+      summary: Get MQTT configuration
+      description: |
+        Returns MQTT integration settings.
+        For security reasons, the password is never returned directly.
+      operationId: getMqttConfig
+      responses:
+        "200":
+          description: MQTT configuration
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MqttConfigResponse"
+
+    put:
+      tags: [MQTT]
+      summary: Create or update MQTT configuration
+      description: |
+        Stores MQTT broker settings used for local push to Home Assistant.
+        If enabled, a live MQTT push is attempted immediately.
+      operationId: upsertMqttConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MqttConfigRequest"
+            example:
+              enabled: true
+              brokerUrl: mqtt://192.168.1.10:1883
+              username: homeassistant
+              password: supersecret
+              topicPrefix: chargeflow
+              discoveryPrefix: homeassistant
+              clientId: chargeflow-server
+      responses:
+        "200":
+          description: Successfully saved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "400":
+          description: Invalid MQTT settings
+        "502":
+          description: Settings were saved, but initial MQTT push failed
+
+  /api/mqtt/push:
+    post:
+      tags: [MQTT]
+      summary: Trigger manual MQTT push
+      description: |
+        Publishes the current vehicle and charging snapshot to MQTT immediately.
+        Requires MQTT integration to be enabled.
+      operationId: pushMqttSnapshot
+      responses:
+        "200":
+          description: Successfully pushed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+        "400":
+          description: MQTT is disabled or invalid request
+        "502":
+          description: MQTT publish failed
 
 components:
   schemas:
@@ -308,3 +379,71 @@ components:
         ok:
           type: boolean
           example: true
+
+    MqttConfigRequest:
+      type: object
+      description: MQTT broker settings for local push
+      properties:
+        enabled:
+          type: boolean
+          description: Enables/disables MQTT push integration
+          example: true
+        brokerUrl:
+          type: string
+          description: Broker URL including protocol (mqtt:// or mqtts://)
+          example: mqtt://192.168.1.10:1883
+        username:
+          type: string
+          description: MQTT broker username
+          example: homeassistant
+        password:
+          type: string
+          description: MQTT broker password
+          example: supersecret
+        topicPrefix:
+          type: string
+          description: Base topic used for state publishing
+          example: chargeflow
+        discoveryPrefix:
+          type: string
+          description: Home Assistant discovery prefix
+          example: homeassistant
+        clientId:
+          type: string
+          description: Optional MQTT client ID for ChargeFlow
+          example: chargeflow-server
+
+    MqttConfigResponse:
+      type: object
+      description: MQTT configuration response with password state only
+      required:
+        - enabled
+        - brokerUrl
+        - username
+        - passwordSet
+        - topicPrefix
+        - discoveryPrefix
+        - clientId
+      properties:
+        enabled:
+          type: boolean
+          example: true
+        brokerUrl:
+          type: string
+          example: mqtt://192.168.1.10:1883
+        username:
+          type: string
+          example: homeassistant
+        passwordSet:
+          type: boolean
+          description: Indicates whether a password is stored
+          example: true
+        topicPrefix:
+          type: string
+          example: chargeflow
+        discoveryPrefix:
+          type: string
+          example: homeassistant
+        clientId:
+          type: string
+          example: chargeflow-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
+        "mqtt": "^5.15.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tsx": "^4.21.0",
@@ -271,6 +272,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1751,7 +1761,6 @@
       "version": "24.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1791,6 +1800,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -1818,6 +1836,15 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -2135,6 +2162,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2320,6 +2359,18 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/broker-factory": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.13.tgz",
+      "integrity": "sha512-H2VALe31mEtO/SRcNp4cUU5BAm1biwhc/JaF77AigUuni/1YT0FLCJfbUxwIEs9y6Kssjk2fmXgf+Y9ALvmKlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-unique-numbers": "^9.0.26",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.48"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2377,6 +2428,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2490,12 +2547,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -2984,6 +3062,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -3074,6 +3170,19 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.26",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.26.tgz",
+      "integrity": "sha512-3Mtq8p1zQinjGyWfKeuBunbuFoixG72AUkk4VvzbX4ykCW9Q4FzRaNyIlfQhUjnKw2ARVP+/CKnoyr6wfHftig==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3371,6 +3480,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -3555,6 +3670,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-tokens": {
@@ -4057,6 +4182,147 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/mqtt": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.0.tgz",
+      "integrity": "sha512-KC+wAssYk83Qu5bT8YDzDYgUJxPhbLeVsDvpY2QvL28PnXYJzC2WkKruyMUgBAZaQ7h9lo9k2g4neRNUUxzgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/mqtt-packet/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4134,6 +4400,16 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -4356,6 +4632,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4515,6 +4806,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -4810,6 +5107,30 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4818,6 +5139,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/statuses": {
@@ -4952,6 +5282,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -5010,6 +5346,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5052,7 +5394,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5234,11 +5575,79 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/worker-factory": {
+      "version": "7.0.48",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.48.tgz",
+      "integrity": "sha512-CGmBy3tJvpBPjUvb0t4PrpKubUsfkI1Ohg0/GGFU2RvA9j/tiVYwKU8O7yu7gH06YtzbeJLzdUR29lmZKn5pag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-unique-numbers": "^9.0.26",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.30",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.30.tgz",
+      "integrity": "sha512-8P7YoMHWN0Tz7mg+9oEhuZdjBIn2z6gfjlJqFcHiDd9no/oLnMGCARCDkV1LR3ccQus62ZdtIp7t3aTKrMLHOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.15",
+        "worker-timers-worker": "^9.0.13"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.15",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.15.tgz",
+      "integrity": "sha512-Te+EiVUMzG5TtHdmaBZvBrZSFNauym6ImDaCAnzQUxvjnw+oGjMT2idmAOgDy30vOZMLejd0bcsc90Axu6XPWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "broker-factory": "^3.1.13",
+        "fast-unique-numbers": "^9.0.26",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.13"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.13.tgz",
+      "integrity": "sha512-qjn18szGb1kjcmh2traAdki1eiIS5ikFo+L90nfMOvSRpuDw1hAcR1nzkP2+Hkdqz5thIRnfuWx7QSpsEUsA6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.48"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
+    "mqtt": "^5.15.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tsx": "^4.21.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import Database from 'better-sqlite3';
+import mqtt, { type IClientOptions, type MqttClient } from 'mqtt';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
@@ -12,7 +13,55 @@ const PORT = parseInt(process.env.PORT || '3001', 10);
 const CSV_PATH = process.env.CSV_PATH || '';
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const TOPIC_SEGMENT_REGEX = /^[a-zA-Z0-9_\-/]+$/;
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+const MQTT_ENV_ENABLED = process.env.MQTT_ENABLED === 'true';
+const MQTT_ENV_BROKER_URL = process.env.MQTT_BROKER_URL || '';
+const MQTT_ENV_USERNAME = process.env.MQTT_USERNAME || '';
+const MQTT_ENV_PASSWORD = process.env.MQTT_PASSWORD || '';
+const MQTT_ENV_TOPIC_PREFIX = process.env.MQTT_TOPIC_PREFIX || 'chargeflow';
+const MQTT_ENV_DISCOVERY_PREFIX = process.env.MQTT_DISCOVERY_PREFIX || 'homeassistant';
+const MQTT_ENV_CLIENT_ID = process.env.MQTT_CLIENT_ID || '';
+
+interface CarData {
+    name: string;
+    batteryCapacityKWh: number;
+    maxDCChargingKW: number;
+    maxACChargingKW: number;
+}
+
+interface ChargingSession {
+    id: string;
+    date: string;
+    kWhCharged: number;
+    pricePerKWh: number;
+    totalCost: number;
+    note?: string;
+}
+
+interface MqttConfig {
+    enabled: boolean;
+    brokerUrl: string;
+    username: string;
+    password: string;
+    topicPrefix: string;
+    discoveryPrefix: string;
+    clientId: string;
+}
+
+interface HomeAssistantDiscoverySensor {
+    objectId: string;
+    name: string;
+    uniqueSuffix: string;
+    valueTemplate: string;
+    unitOfMeasurement?: string;
+    deviceClass?: string;
+    stateClass?: string;
+    icon?: string;
+}
+
+let mqttClient: MqttClient | null = null;
+let mqttClientConfigKey = '';
 
 // ── Database Setup ──
 const dbPath = process.env.DB_PATH || path.join(__dirname, 'chargeflow.db');
@@ -43,6 +92,33 @@ db.exec(`
 db.exec(`
   CREATE INDEX IF NOT EXISTS idx_session_date ON charging_session(date DESC);
 `);
+
+db.exec(`
+    CREATE TABLE IF NOT EXISTS mqtt_config (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        enabled INTEGER NOT NULL DEFAULT 0,
+        broker_url TEXT NOT NULL DEFAULT '',
+        username TEXT NOT NULL DEFAULT '',
+        password TEXT NOT NULL DEFAULT '',
+        topic_prefix TEXT NOT NULL DEFAULT 'chargeflow',
+        discovery_prefix TEXT NOT NULL DEFAULT 'homeassistant',
+        client_id TEXT NOT NULL DEFAULT ''
+    );
+`);
+
+db.prepare(`
+    INSERT INTO mqtt_config (id, enabled, broker_url, username, password, topic_prefix, discovery_prefix, client_id)
+    VALUES (1, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO NOTHING
+`).run(
+    MQTT_ENV_ENABLED ? 1 : 0,
+    MQTT_ENV_BROKER_URL,
+    MQTT_ENV_USERNAME,
+    MQTT_ENV_PASSWORD,
+    MQTT_ENV_TOPIC_PREFIX,
+    MQTT_ENV_DISCOVERY_PREFIX,
+    MQTT_ENV_CLIENT_ID
+);
 
 // ── Middleware ──
 app.disable('x-powered-by');
@@ -165,26 +241,394 @@ function syncCsv(): void {
     }
 }
 
+function getCarData(): CarData {
+    const row = db.prepare('SELECT name, battery_capacity_kwh, max_dc_charging_kw, max_ac_charging_kw FROM car WHERE id = 1').get() as Record<string, unknown> | undefined;
+    if (!row) {
+        return { name: '', batteryCapacityKWh: 0, maxDCChargingKW: 0, maxACChargingKW: 0 };
+    }
+    return {
+        name: String(row.name),
+        batteryCapacityKWh: Number(row.battery_capacity_kwh),
+        maxDCChargingKW: Number(row.max_dc_charging_kw),
+        maxACChargingKW: Number(row.max_ac_charging_kw),
+    };
+}
+
+function getSessionsData(): ChargingSession[] {
+    const rows = db.prepare('SELECT id, date, kwh_charged, price_per_kwh, total_cost, note FROM charging_session ORDER BY date DESC').all() as Record<string, unknown>[];
+    return rows.map((row) => ({
+        id: String(row.id),
+        date: String(row.date),
+        kWhCharged: Number(row.kwh_charged),
+        pricePerKWh: Number(row.price_per_kwh),
+        totalCost: Number(row.total_cost),
+        note: row.note ? String(row.note) : undefined,
+    }));
+}
+
+function getMqttConfig(): MqttConfig {
+    const row = db.prepare('SELECT enabled, broker_url, username, password, topic_prefix, discovery_prefix, client_id FROM mqtt_config WHERE id = 1').get() as Record<string, unknown> | undefined;
+    if (!row) {
+        return {
+            enabled: false,
+            brokerUrl: '',
+            username: '',
+            password: '',
+            topicPrefix: 'chargeflow',
+            discoveryPrefix: 'homeassistant',
+            clientId: '',
+        };
+    }
+    return {
+        enabled: Number(row.enabled) === 1,
+        brokerUrl: String(row.broker_url),
+        username: String(row.username),
+        password: String(row.password),
+        topicPrefix: String(row.topic_prefix),
+        discoveryPrefix: String(row.discovery_prefix),
+        clientId: String(row.client_id),
+    };
+}
+
+function normalizeTopicSegment(input: string): string {
+    return input
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_\-/]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^[_/-]+|[_/-]+$/g, '') || 'chargeflow';
+}
+
+function buildMqttDeviceId(carName: string): string {
+    const slug = normalizeTopicSegment(carName || 'car');
+    return `chargeflow_${slug.replace(/[\-/]/g, '_')}`;
+}
+
+function getMqttClientConfigKey(config: MqttConfig): string {
+    return [config.brokerUrl, config.username, config.password, config.clientId].join('|');
+}
+
+function publishMqtt(client: MqttClient, topic: string, payload: string, retain = true): Promise<void> {
+    return new Promise((resolve, reject) => {
+        client.publish(topic, payload, { qos: 1, retain }, (err) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+function validateMqttConfig(config: MqttConfig): string | null {
+    if (typeof config.enabled !== 'boolean') {
+        return 'Invalid enabled (boolean required)';
+    }
+    if (typeof config.brokerUrl !== 'string' || config.brokerUrl.length > 500) {
+        return 'Invalid brokerUrl (string, max 500 chars)';
+    }
+    if (config.enabled && config.brokerUrl.trim().length === 0) {
+        return 'brokerUrl is required when MQTT is enabled';
+    }
+    if (config.enabled && !/^mqtts?:\/\//.test(config.brokerUrl.trim())) {
+        return 'brokerUrl must start with mqtt:// or mqtts://';
+    }
+    if (typeof config.username !== 'string' || config.username.length > 200) {
+        return 'Invalid username (max 200 chars)';
+    }
+    if (typeof config.password !== 'string' || config.password.length > 500) {
+        return 'Invalid password (max 500 chars)';
+    }
+    if (config.enabled && config.username.trim().length === 0) {
+        return 'username is required when MQTT is enabled';
+    }
+    if (config.enabled && config.password.length === 0) {
+        return 'password is required when MQTT is enabled';
+    }
+    if (typeof config.topicPrefix !== 'string' || config.topicPrefix.length === 0 || config.topicPrefix.length > 200) {
+        return 'Invalid topicPrefix (string, 1-200 chars)';
+    }
+    if (!TOPIC_SEGMENT_REGEX.test(config.topicPrefix)) {
+        return 'Invalid topicPrefix (allowed: letters, numbers, _, -, /)';
+    }
+    if (typeof config.discoveryPrefix !== 'string' || config.discoveryPrefix.length === 0 || config.discoveryPrefix.length > 200) {
+        return 'Invalid discoveryPrefix (string, 1-200 chars)';
+    }
+    if (!TOPIC_SEGMENT_REGEX.test(config.discoveryPrefix)) {
+        return 'Invalid discoveryPrefix (allowed: letters, numbers, _, -, /)';
+    }
+    if (typeof config.clientId !== 'string' || config.clientId.length > 200) {
+        return 'Invalid clientId (max 200 chars)';
+    }
+    return null;
+}
+
+async function ensureMqttClient(config: MqttConfig): Promise<MqttClient> {
+    const configKey = getMqttClientConfigKey(config);
+    if (mqttClient && mqttClient.connected && mqttClientConfigKey === configKey) {
+        return mqttClient;
+    }
+
+    if (mqttClient) {
+        mqttClient.end(true);
+        mqttClient = null;
+        mqttClientConfigKey = '';
+    }
+
+    const options: IClientOptions = {
+        username: config.username,
+        password: config.password,
+        reconnectPeriod: 0,
+        connectTimeout: 5000,
+        clean: true,
+        clientId: config.clientId.trim().length > 0
+            ? config.clientId.trim()
+            : `chargeflow_${Math.random().toString(16).slice(2, 10)}`,
+    };
+
+    const client = mqtt.connect(config.brokerUrl.trim(), options);
+
+    await new Promise<void>((resolve, reject) => {
+        const onConnect = (): void => {
+            client.off('error', onError);
+            resolve();
+        };
+        const onError = (err: Error): void => {
+            client.off('connect', onConnect);
+            reject(err);
+        };
+
+        client.once('connect', onConnect);
+        client.once('error', onError);
+    });
+
+    mqttClient = client;
+    mqttClientConfigKey = configKey;
+    return client;
+}
+
+function getDiscoverySensors(): HomeAssistantDiscoverySensor[] {
+    return [
+        {
+            objectId: 'car_name',
+            name: 'Car Name',
+            uniqueSuffix: 'car_name',
+            valueTemplate: '{{ value_json.car.name }}',
+            icon: 'mdi:car-electric',
+        },
+        {
+            objectId: 'battery_capacity_kwh',
+            name: 'Battery Capacity',
+            uniqueSuffix: 'battery_capacity_kwh',
+            valueTemplate: '{{ value_json.car.batteryCapacityKWh }}',
+            unitOfMeasurement: 'kWh',
+            stateClass: 'measurement',
+            icon: 'mdi:car-battery',
+        },
+        {
+            objectId: 'max_dc_charging_kw',
+            name: 'Max DC Charging',
+            uniqueSuffix: 'max_dc_charging_kw',
+            valueTemplate: '{{ value_json.car.maxDCChargingKW }}',
+            unitOfMeasurement: 'kW',
+            stateClass: 'measurement',
+            icon: 'mdi:lightning-bolt',
+        },
+        {
+            objectId: 'max_ac_charging_kw',
+            name: 'Max AC Charging',
+            uniqueSuffix: 'max_ac_charging_kw',
+            valueTemplate: '{{ value_json.car.maxACChargingKW }}',
+            unitOfMeasurement: 'kW',
+            stateClass: 'measurement',
+            icon: 'mdi:lightning-bolt-outline',
+        },
+        {
+            objectId: 'total_cost',
+            name: 'Total Cost',
+            uniqueSuffix: 'total_cost',
+            valueTemplate: '{{ value_json.statistics.totalCost }}',
+            unitOfMeasurement: 'EUR',
+            icon: 'mdi:currency-eur',
+            stateClass: 'measurement',
+        },
+        {
+            objectId: 'total_kwh',
+            name: 'Total Energy',
+            uniqueSuffix: 'total_kwh',
+            valueTemplate: '{{ value_json.statistics.totalKWh }}',
+            unitOfMeasurement: 'kWh',
+            deviceClass: 'energy',
+            stateClass: 'measurement',
+            icon: 'mdi:ev-station',
+        },
+        {
+            objectId: 'session_count',
+            name: 'Session Count',
+            uniqueSuffix: 'session_count',
+            valueTemplate: '{{ value_json.statistics.sessionCount }}',
+            stateClass: 'measurement',
+            icon: 'mdi:counter',
+        },
+        {
+            objectId: 'avg_price_per_kwh',
+            name: 'Avg Price per kWh',
+            uniqueSuffix: 'avg_price_per_kwh',
+            valueTemplate: '{{ value_json.statistics.avgPricePerKWh }}',
+            unitOfMeasurement: 'EUR/kWh',
+            stateClass: 'measurement',
+            icon: 'mdi:chart-line',
+        },
+        {
+            objectId: 'current_month_kwh',
+            name: 'Current Month Energy',
+            uniqueSuffix: 'current_month_kwh',
+            valueTemplate: '{{ value_json.statistics.currentMonthKWh }}',
+            unitOfMeasurement: 'kWh',
+            deviceClass: 'energy',
+            stateClass: 'measurement',
+            icon: 'mdi:calendar-month',
+        },
+        {
+            objectId: 'current_month_cost',
+            name: 'Current Month Cost',
+            uniqueSuffix: 'current_month_cost',
+            valueTemplate: '{{ value_json.statistics.currentMonthCost }}',
+            unitOfMeasurement: 'EUR',
+            stateClass: 'measurement',
+            icon: 'mdi:cash-multiple',
+        },
+        {
+            objectId: 'avg_kwh_per_month',
+            name: 'Avg Energy per Month',
+            uniqueSuffix: 'avg_kwh_per_month',
+            valueTemplate: '{{ value_json.statistics.avgKWhPerMonth }}',
+            unitOfMeasurement: 'kWh/month',
+            stateClass: 'measurement',
+            icon: 'mdi:chart-bar',
+        },
+        {
+            objectId: 'avg_cost_per_month',
+            name: 'Avg Cost per Month',
+            uniqueSuffix: 'avg_cost_per_month',
+            valueTemplate: '{{ value_json.statistics.avgCostPerMonth }}',
+            unitOfMeasurement: 'EUR/month',
+            stateClass: 'measurement',
+            icon: 'mdi:chart-line-variant',
+        },
+    ];
+}
+
+async function pushMqttSnapshot(): Promise<void> {
+    const config = getMqttConfig();
+    if (!config.enabled) return;
+
+    const validationError = validateMqttConfig(config);
+    if (validationError) {
+        throw new Error(validationError);
+    }
+
+    const car = getCarData();
+    const sessions = getSessionsData();
+    const deviceName = car.name.trim() || 'ChargeFlow Car';
+    const deviceId = buildMqttDeviceId(deviceName);
+    const topicPrefix = normalizeTopicSegment(config.topicPrefix);
+    const discoveryPrefix = normalizeTopicSegment(config.discoveryPrefix);
+    const stateTopic = `${topicPrefix}/${deviceId}/state`;
+    const discoveryBase = `${discoveryPrefix}/sensor/${deviceId}`;
+
+    const sessionCount = sessions.length;
+    const totalKWh = sessions.reduce((sum, session) => sum + session.kWhCharged, 0);
+    const totalCost = sessions.reduce((sum, session) => sum + session.totalCost, 0);
+    const avgPricePerKWh = totalKWh > 0 ? totalCost / totalKWh : 0;
+
+    const now = new Date();
+    const currentMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    const monthlyTotals = new Map<string, { kWh: number; cost: number }>();
+
+    for (const session of sessions) {
+        const key = session.date.slice(0, 7);
+        const entry = monthlyTotals.get(key) || { kWh: 0, cost: 0 };
+        entry.kWh += session.kWhCharged;
+        entry.cost += session.totalCost;
+        monthlyTotals.set(key, entry);
+    }
+
+    const currentMonth = monthlyTotals.get(currentMonthKey) || { kWh: 0, cost: 0 };
+    const monthCount = monthlyTotals.size;
+    const avgKWhPerMonth = monthCount > 0
+        ? Array.from(monthlyTotals.values()).reduce((sum, value) => sum + value.kWh, 0) / monthCount
+        : 0;
+    const avgCostPerMonth = monthCount > 0
+        ? Array.from(monthlyTotals.values()).reduce((sum, value) => sum + value.cost, 0) / monthCount
+        : 0;
+
+    const statePayload = JSON.stringify({
+        updatedAt: new Date().toISOString(),
+        car,
+        sessions,
+        statistics: {
+            sessionCount,
+            totalKWh,
+            totalCost,
+            avgPricePerKWh,
+            currentMonthKWh: currentMonth.kWh,
+            currentMonthCost: currentMonth.cost,
+            avgKWhPerMonth,
+            avgCostPerMonth,
+            monthCount,
+        },
+    });
+
+    const discoverySensors = getDiscoverySensors();
+
+    const client = await ensureMqttClient(config);
+    for (const sensor of discoverySensors) {
+        const discoveryTopic = `${discoveryBase}/${sensor.objectId}/config`;
+        const discoveryPayload = JSON.stringify({
+            name: sensor.name,
+            unique_id: `${deviceId}_${sensor.uniqueSuffix}`,
+            state_topic: stateTopic,
+            value_template: sensor.valueTemplate,
+            unit_of_measurement: sensor.unitOfMeasurement,
+            device_class: sensor.deviceClass,
+            state_class: sensor.stateClass,
+            icon: sensor.icon,
+            json_attributes_topic: stateTopic,
+            device: {
+                identifiers: [deviceId],
+                name: deviceName,
+                manufacturer: 'ChargeFlow',
+                model: 'EV Charging Tracker',
+            },
+        });
+        await publishMqtt(client, discoveryTopic, discoveryPayload, true);
+    }
+    await publishMqtt(client, stateTopic, statePayload, true);
+}
+
+async function syncExternalTargets(): Promise<void> {
+    syncCsv();
+    try {
+        await pushMqttSnapshot();
+    } catch (err) {
+        console.error('MQTT push error:', err);
+    }
+}
+
 // Initial sync on startup
 syncCsv();
+void pushMqttSnapshot().catch((err) => {
+    console.error('Initial MQTT push error:', err);
+});
 
 // ── Car Routes ──
 
 app.get('/api/car', (_req, res) => {
-    const row = db.prepare('SELECT name, battery_capacity_kwh, max_dc_charging_kw, max_ac_charging_kw FROM car WHERE id = 1').get() as Record<string, unknown> | undefined;
-    if (!row) {
-        res.json({ name: '', batteryCapacityKWh: 0, maxDCChargingKW: 0, maxACChargingKW: 0 });
-        return;
-    }
-    res.json({
-        name: row.name,
-        batteryCapacityKWh: row.battery_capacity_kwh,
-        maxDCChargingKW: row.max_dc_charging_kw,
-        maxACChargingKW: row.max_ac_charging_kw,
-    });
+    res.json(getCarData());
 });
 
-app.put('/api/car', ...mutationMiddleware, (req, res) => {
+app.put('/api/car', ...mutationMiddleware, async (req, res) => {
     const { name, batteryCapacityKWh, maxDCChargingKW, maxACChargingKW } = req.body;
 
     // Input validation
@@ -214,7 +658,7 @@ app.put('/api/car', ...mutationMiddleware, (req, res) => {
       max_dc_charging_kw = excluded.max_dc_charging_kw,
       max_ac_charging_kw = excluded.max_ac_charging_kw
   `).run(name.trim(), batteryCapacityKWh, maxDCChargingKW, maxACChargingKW);
-    syncCsv();
+    await syncExternalTargets();
     res.json({ ok: true });
 });
 
@@ -249,19 +693,10 @@ function validateSessionFields(input: {
 }
 
 app.get('/api/sessions', (_req, res) => {
-    const rows = db.prepare('SELECT id, date, kwh_charged, price_per_kwh, total_cost, note FROM charging_session ORDER BY date DESC').all() as Record<string, unknown>[];
-    const sessions = rows.map((row) => ({
-        id: row.id,
-        date: row.date,
-        kWhCharged: row.kwh_charged,
-        pricePerKWh: row.price_per_kwh,
-        totalCost: row.total_cost,
-        note: row.note || undefined,
-    }));
-    res.json(sessions);
+    res.json(getSessionsData());
 });
 
-app.post('/api/sessions', ...mutationMiddleware, (req, res) => {
+app.post('/api/sessions', ...mutationMiddleware, async (req, res) => {
     const { id, date, kWhCharged, pricePerKWh, totalCost, note } = req.body;
 
     // Input validation
@@ -280,11 +715,11 @@ app.post('/api/sessions', ...mutationMiddleware, (req, res) => {
     INSERT INTO charging_session (id, date, kwh_charged, price_per_kwh, total_cost, note)
     VALUES (?, ?, ?, ?, ?, ?)
   `).run(id, date, kWhCharged, pricePerKWh, totalCost, note ?? null);
-    syncCsv();
+    await syncExternalTargets();
     res.json({ ok: true });
 });
 
-app.put('/api/sessions/:id', ...mutationMiddleware, (req, res) => {
+app.put('/api/sessions/:id', ...mutationMiddleware, async (req, res) => {
     const { id } = req.params;
     const { date, kWhCharged, pricePerKWh, totalCost, note } = req.body;
 
@@ -310,14 +745,114 @@ app.put('/api/sessions/:id', ...mutationMiddleware, (req, res) => {
         return;
     }
 
-    syncCsv();
+    await syncExternalTargets();
     res.json({ ok: true });
 });
 
-app.delete('/api/sessions/:id', ...mutationMiddleware, (req, res) => {
+app.delete('/api/sessions/:id', ...mutationMiddleware, async (req, res) => {
     db.prepare('DELETE FROM charging_session WHERE id = ?').run(req.params.id);
-    syncCsv();
+    await syncExternalTargets();
     res.json({ ok: true });
+});
+
+// ── MQTT Routes ──
+
+app.get('/api/mqtt', (_req, res) => {
+    const config = getMqttConfig();
+    res.json({
+        enabled: config.enabled,
+        brokerUrl: config.brokerUrl,
+        username: config.username,
+        passwordSet: config.password.length > 0,
+        topicPrefix: config.topicPrefix,
+        discoveryPrefix: config.discoveryPrefix,
+        clientId: config.clientId,
+    });
+});
+
+app.put('/api/mqtt', ...mutationMiddleware, async (req, res) => {
+    const current = getMqttConfig();
+    const payload = req.body as Record<string, unknown>;
+
+    if (payload.enabled !== undefined && typeof payload.enabled !== 'boolean') {
+        res.status(400).json({ error: 'Invalid enabled (boolean required)' });
+        return;
+    }
+
+    const nextConfig: MqttConfig = {
+        enabled: payload.enabled === undefined ? current.enabled : payload.enabled,
+        brokerUrl: typeof payload.brokerUrl === 'string' ? payload.brokerUrl.trim() : current.brokerUrl,
+        username: typeof payload.username === 'string' ? payload.username.trim() : current.username,
+        password: typeof payload.password === 'string' ? payload.password : current.password,
+        topicPrefix: typeof payload.topicPrefix === 'string' ? payload.topicPrefix.trim() : current.topicPrefix,
+        discoveryPrefix: typeof payload.discoveryPrefix === 'string' ? payload.discoveryPrefix.trim() : current.discoveryPrefix,
+        clientId: typeof payload.clientId === 'string' ? payload.clientId.trim() : current.clientId,
+    };
+
+    const validationError = validateMqttConfig(nextConfig);
+    if (validationError) {
+        res.status(400).json({ error: validationError });
+        return;
+    }
+
+    db.prepare(`
+            INSERT INTO mqtt_config (id, enabled, broker_url, username, password, topic_prefix, discovery_prefix, client_id)
+            VALUES (1, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        enabled = excluded.enabled,
+        broker_url = excluded.broker_url,
+        username = excluded.username,
+        password = excluded.password,
+        topic_prefix = excluded.topic_prefix,
+        discovery_prefix = excluded.discovery_prefix,
+                client_id = excluded.client_id
+    `).run(
+        nextConfig.enabled ? 1 : 0,
+        nextConfig.brokerUrl,
+        nextConfig.username,
+        nextConfig.password,
+        nextConfig.topicPrefix,
+        nextConfig.discoveryPrefix,
+        nextConfig.clientId
+    );
+
+    if (!nextConfig.enabled && mqttClient) {
+        mqttClient.end(true);
+        mqttClient = null;
+        mqttClientConfigKey = '';
+    }
+
+    if (nextConfig.enabled) {
+        try {
+            await pushMqttSnapshot();
+        } catch (err) {
+            res.status(502).json({
+                error: 'MQTT configuration saved, but push failed',
+                details: err instanceof Error ? err.message : 'Unknown MQTT error',
+            });
+            return;
+        }
+    }
+
+    res.json({ ok: true });
+});
+
+app.post('/api/mqtt/push', ...mutationMiddleware, async (_req, res) => {
+    const config = getMqttConfig();
+    if (!config.enabled) {
+        res.status(400).json({ error: 'MQTT is disabled' });
+        return;
+    }
+
+    try {
+        await pushMqttSnapshot();
+        res.json({ ok: true });
+    } catch (err) {
+        res.status(502).json({
+            error: 'MQTT push failed',
+            details: err instanceof Error ? err.message : 'Unknown MQTT error',
+        });
+    }
 });
 
 // ── Static Files (production) ──


### PR DESCRIPTION
This PR adds local MQTT push support for ChargeFlow, designed for Home Assistant via a Mosquitto broker with username/password authentication.

- Added MQTT configuration and management API (GET /api/mqtt, PUT /api/mqtt, POST /api/mqtt/push).
- Added authenticated MQTT publishing of a full state snapshot (car, sessions, statistics) on every data mutation.
- Implemented Home Assistant MQTT Discovery with a device named after the configured car.
- Added dedicated HA sensors for:
    - Car data (name, battery capacity, max AC/DC power)
    - Totals (cost, energy, session count, avg price/kWh)
    - Monthly KPIs (current month kWh/cost, avg kWh per month, avg cost per month)
- Improved sensor naming for cleaner Home Assistant UI labels.
- Updated API/documentation and verified successful build (npm run build).